### PR TITLE
Adding configuration to specify wsdl_hostname to be used in distributed ...

### DIFF
--- a/demos/DemoServicesHostname.py
+++ b/demos/DemoServicesHostname.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Copyright 2011 Rodrigo Ancavil del Pino
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import tornado.httpserver
+import tornado.ioloop
+
+from tornado.options import define, options
+from tornadows import soaphandler
+from tornadows import webservices
+from tornadows import xmltypes
+from tornadows.soaphandler import webservice
+
+# If you plan server this webservice in many machines, please set up your
+# main domain here. Useful to work in a round-robin way or reverse proxy.
+define("wsdl_hostname", default="mydomain.com", help="WSDL Hostname")
+
+class EchoService(soaphandler.SoapHandler):
+	""" Echo Service """
+	@webservice(_params=xmltypes.String,_returns=xmltypes.String)
+  	def echo(self, message):
+		return 'Echo say : %s' % message
+
+class EchoTargetnsService(soaphandler.SoapHandler):
+	""" Service to test the use of an overrided target namespace address """
+	targetns_address = '192.168.0.103'
+	@webservice(_params=xmltypes.String, _returns=xmltypes.String)
+  	def echo(self, message):
+		return 'Echo say : %s' % message
+
+class CountService(soaphandler.SoapHandler):
+	""" Service that counts the number of items in a list """
+   	@webservice(_params=xmltypes.Array(xmltypes.String),_returns=xmltypes.Integer)
+	def count(self, list_of_values):
+		length = len(list_of_values)
+		return length
+
+class DivService(soaphandler.SoapHandler):
+	""" Service that provides the division operation of two float numbers """
+	@webservice(_params=[xmltypes.Float,xmltypes.Float],_returns=xmltypes.Float)
+	def div(self, a, b):
+		result = a/b
+		return result
+
+class FibonacciService(soaphandler.SoapHandler):
+	""" Service that provides Fibonacci numbers """
+	@webservice(_params=xmltypes.Integer,_returns=xmltypes.Array(xmltypes.Integer))
+	def fib(self,n):
+		a, b = 0, 1
+		result = []
+		while b < n:
+			result.append(b)
+			a, b = b, a + b
+		return result
+
+if __name__ == '__main__':
+  	service = [('EchoService',EchoService),
+        	   ('EchoTargetnsService', EchoTargetnsService),
+        	   ('CountService',CountService),
+             	   ('DivService',DivService),
+             	   ('FibonacciService',FibonacciService)]
+  	app = webservices.WebService(service)
+  	ws  = tornado.httpserver.HTTPServer(app)
+  	ws.listen(8080)
+  	tornado.ioloop.IOLoop.instance().start()

--- a/demos/README
+++ b/demos/README
@@ -42,6 +42,14 @@ The example display four separate services.
 You can probe this services with SoapUI or creating a web services client with 
 your favorite programming language.
 
+Running the DemoServiceHostname.py example:
+-------------------------------------------
+
+	The results are the same as above showed, except that in this demo you can
+	set the hostname to be answered in the WSDL. It's useful when you need to 
+	run the services in distributed servers architecture. It's gonna be useful
+	operating in a round-robin or reverse proxy configuration.
+
 Running the DemoService2.py example:
 ------------------------.-----------
 

--- a/tornadows/soaphandler.py
+++ b/tornadows/soaphandler.py
@@ -21,6 +21,7 @@ import tornado.web
 import xml.dom.minidom
 import string
 import inspect
+from tornado.options import options
 from tornadows import soap
 from tornadows import xmltypes
 from tornadows import complextypes
@@ -101,7 +102,11 @@ class SoapHandler(tornado.web.RequestHandler):
 		""" Method get() returned the WSDL. If wsdl_path is null, the
 		    WSDL is generated dinamically.
 		"""
-		address = getattr(self, 'targetns_address',tornado.httpserver.socket.gethostbyname(tornado.httpserver.socket.gethostname()))
+		if type(options.wsdl_hostname) is str:
+			address = options.wsdl_hostname
+		else:
+			address = getattr(self, 'targetns_address',tornado.httpserver.socket.gethostbyname(tornado.httpserver.socket.gethostname()))
+		
 		port = 80 # if you are using the port 80
 		if len(self.request.headers['Host'].split(':')) >= 2:
 			port = self.request.headers['Host'].split(':')[1]


### PR DESCRIPTION
Hello, I'd like to contribute with a little but useful change. Recently I needed to serve my webservices to SOAP format and I used your lib. Thanks about that. 
So I had a problem when I needed to serve the same webservice in a round-robin configuration. I have a main domain to access the webservice appointing to three machines running the SOAP Server. 
When a user sent a request to the server, ocurred a problem, cause the tornadows answered the server IP in WSDL, not the main domain that the user had configured. 
To fix this problem I made a little change and documented it, as you can take a look. It's gonna be useful to many people that has an architecture like mine.
If you think that it is pertinent, feel free to include the changes to the project.

Thanks!
